### PR TITLE
init: Add a -nomempool option

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1218,7 +1218,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     assert(!node.peerman);
     node.peerman = PeerManager::make(chainparams, *node.connman, *node.addrman, node.banman.get(),
-                                     chainman, *node.mempool, ignores_incoming_txs);
+                                     chainman, node.mempool.get(), ignores_incoming_txs);
     RegisterValidationInterface(node.peerman.get());
 
     // sanitize comments per BIP-0014, format user agent and check total size

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -699,13 +699,13 @@ void InitParameterInteraction(ArgsManager& args)
             LogPrintf("%s: parameter interaction: -whitelistforcerelay=1 -> setting -whitelistrelay=1\n", __func__);
     }
 
-    // If mempool is disabled,
-    if (!args.GetBoolArg("-mempool", DEFAULT_INITMEMPOOL)) {
-        if (args.SoftSetBoolArg("-whitelistrelay", false))
-            LogPrintf("%s: parameter interaction: -mempool=0 -> setting -whitelistrelay=0\n", __func__);
-        if (args.SoftSetBoolArg("-walletbroadcast", false))
-            LogPrintf("%s: parameter interaction: -mempool=0 -> setting -walletbroadcast=0\n", __func__);
-    }
+    // // If mempool is disabled,
+    // if (!args.GetBoolArg("-mempool", DEFAULT_INITMEMPOOL)) {
+    //     if (args.SoftSetBoolArg("-whitelistrelay", false))
+    //         LogPrintf("%s: parameter interaction: -mempool=0 -> setting -whitelistrelay=0\n", __func__);
+    //     if (args.SoftSetBoolArg("-walletbroadcast", false))
+    //         LogPrintf("%s: parameter interaction: -mempool=0 -> setting -walletbroadcast=0\n", __func__);
+    // }
 }
 
 /**
@@ -1180,9 +1180,10 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     fListen = args.GetBoolArg("-listen", DEFAULT_LISTEN);
     fDiscover = args.GetBoolArg("-discover", true);
-    const bool ignores_incoming_txs{
-        args.GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY) || !args.GetBoolArg("-mempool", DEFAULT_INITMEMPOOL)
-        };
+    // const bool ignores_incoming_txs{
+    //     args.GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY) || !args.GetBoolArg("-mempool", DEFAULT_INITMEMPOOL)
+    //     };
+    const bool ignores_incoming_txs = args.GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY);
 
     assert(!node.addrman);
     auto check_addrman = std::clamp<int32_t>(args.GetArg("-checkaddrman", DEFAULT_ADDRMAN_CONSISTENCY_CHECKS), 0, 1000000);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -698,6 +698,14 @@ void InitParameterInteraction(ArgsManager& args)
         if (args.SoftSetBoolArg("-whitelistrelay", true))
             LogPrintf("%s: parameter interaction: -whitelistforcerelay=1 -> setting -whitelistrelay=1\n", __func__);
     }
+
+    // If mempool is disabled,
+    if (!args.GetBoolArg("-mempool", DEFAULT_INITMEMPOOL)) {
+        if (args.SoftSetBoolArg("-whitelistrelay", false))
+            LogPrintf("%s: parameter interaction: -mempool=0 -> setting -whitelistrelay=0\n", __func__);
+        if (args.SoftSetBoolArg("-walletbroadcast", false))
+            LogPrintf("%s: parameter interaction: -mempool=0 -> setting -walletbroadcast=0\n", __func__);
+    }
 }
 
 /**
@@ -1172,7 +1180,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     fListen = args.GetBoolArg("-listen", DEFAULT_LISTEN);
     fDiscover = args.GetBoolArg("-discover", true);
-    const bool ignores_incoming_txs{args.GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY)};
+    const bool ignores_incoming_txs{
+        args.GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY) || !args.GetBoolArg("-mempool", DEFAULT_INITMEMPOOL)
+        };
 
     assert(!node.addrman);
     auto check_addrman = std::clamp<int32_t>(args.GetArg("-checkaddrman", DEFAULT_ADDRMAN_CONSISTENCY_CHECKS), 0, 1000000);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -485,6 +485,11 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
         addr_bind = GetBindAddress(sock->Get());
     }
     CNode* pnode = new CNode(id, nLocalServices, sock->Release(), addrConnect, CalculateKeyedNetGroup(addrConnect), nonce, addr_bind, pszDest ? pszDest : "", conn_type, /* inbound_onion */ false);
+    // Not using DEFAULT_INITMEMPOOL since it is declared in txmempool.h
+    if (!gArgs.GetBoolArg("-mempool", true)) {
+        pnode->m_tx_relay = nullptr;
+    }
+
     pnode->AddRef();
 
     // We're making a new connection, harvest entropy from the time (and our peer count)
@@ -1180,6 +1185,12 @@ void CConnman::CreateNodeFromAcceptedSocket(SOCKET hSocket,
 
     const bool inbound_onion = std::find(m_onion_binds.begin(), m_onion_binds.end(), addr_bind) != m_onion_binds.end();
     CNode* pnode = new CNode(id, nodeServices, hSocket, addr, CalculateKeyedNetGroup(addr), nonce, addr_bind, "", ConnectionType::INBOUND, inbound_onion);
+
+    // Not using DEFAULT_INITMEMPOOL since it is declared in txmempool.h
+    if (!gArgs.GetBoolArg("-mempool", true)) {
+        pnode->m_tx_relay = nullptr;
+    }
+    
     pnode->AddRef();
     pnode->m_permissionFlags = permissionFlags;
     pnode->m_prefer_evict = discouraged;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -293,7 +293,7 @@ class PeerManagerImpl final : public PeerManager
 public:
     PeerManagerImpl(const CChainParams& chainparams, CConnman& connman, CAddrMan& addrman,
                     BanMan* banman, ChainstateManager& chainman,
-                    CTxMemPool& pool, bool ignore_incoming_txs);
+                    CTxMemPool* pool, bool ignore_incoming_txs);
 
     /** Overridden from CValidationInterface. */
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected) override;
@@ -413,7 +413,7 @@ private:
     /** Pointer to this node's banman. May be nullptr - check existence before dereferencing. */
     BanMan* const m_banman;
     ChainstateManager& m_chainman;
-    CTxMemPool& m_mempool;
+    CTxMemPool* m_mempool;
     TxRequestTracker m_txrequest GUARDED_BY(::cs_main);
 
     /** The height of the best chain */
@@ -867,7 +867,7 @@ bool PeerManagerImpl::BlockRequested(NodeId nodeid, const CBlockIndex& block, st
     RemoveBlockRequest(hash);
 
     std::list<QueuedBlock>::iterator it = state->vBlocksInFlight.insert(state->vBlocksInFlight.end(),
-            {&block, std::unique_ptr<PartiallyDownloadedBlock>(pit ? new PartiallyDownloadedBlock(&m_mempool) : nullptr)});
+            {&block, std::unique_ptr<PartiallyDownloadedBlock>(pit ? new PartiallyDownloadedBlock(m_mempool) : nullptr)});
     state->nBlocksInFlight++;
     if (state->nBlocksInFlight == 1) {
         // We're starting a block download (batch) from this peer.
@@ -1165,16 +1165,16 @@ void PeerManagerImpl::InitializeNode(CNode *pnode)
 
 void PeerManagerImpl::ReattemptInitialBroadcast(CScheduler& scheduler)
 {
-    std::set<uint256> unbroadcast_txids = m_mempool.GetUnbroadcastTxs();
+    std::set<uint256> unbroadcast_txids = m_mempool->GetUnbroadcastTxs();
 
     for (const auto& txid : unbroadcast_txids) {
-        CTransactionRef tx = m_mempool.get(txid);
+        CTransactionRef tx = m_mempool->get(txid);
 
         if (tx != nullptr) {
             LOCK(cs_main);
             _RelayTransaction(txid, tx->GetWitnessHash());
         } else {
-            m_mempool.RemoveUnbroadcastTx(txid, true);
+            m_mempool->RemoveUnbroadcastTx(txid, true);
         }
     }
 
@@ -1421,14 +1421,14 @@ bool PeerManagerImpl::BlockRequestAllowed(const CBlockIndex* pindex)
 
 std::unique_ptr<PeerManager> PeerManager::make(const CChainParams& chainparams, CConnman& connman, CAddrMan& addrman,
                                                BanMan* banman, ChainstateManager& chainman,
-                                               CTxMemPool& pool, bool ignore_incoming_txs)
+                                               CTxMemPool* pool, bool ignore_incoming_txs)
 {
     return std::make_unique<PeerManagerImpl>(chainparams, connman, addrman, banman, chainman, pool, ignore_incoming_txs);
 }
 
 PeerManagerImpl::PeerManagerImpl(const CChainParams& chainparams, CConnman& connman, CAddrMan& addrman,
                                  BanMan* banman, ChainstateManager& chainman,
-                                 CTxMemPool& pool, bool ignore_incoming_txs)
+                                 CTxMemPool* pool, bool ignore_incoming_txs)
     : m_chainparams(chainparams),
       m_connman(connman),
       m_addrman(addrman),
@@ -1650,7 +1650,7 @@ bool PeerManagerImpl::AlreadyHaveTx(const GenTxid& gtxid)
         if (m_recent_confirmed_transactions.contains(hash)) return true;
     }
 
-    return m_recent_rejects.contains(hash) || m_mempool.exists(gtxid);
+    return m_recent_rejects.contains(hash) || m_mempool->exists(gtxid);
 }
 
 bool PeerManagerImpl::AlreadyHaveBlock(const uint256& block_hash)
@@ -1883,7 +1883,7 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
 
 CTransactionRef PeerManagerImpl::FindTxForGetData(const CNode& peer, const GenTxid& gtxid, const std::chrono::seconds mempool_req, const std::chrono::seconds now)
 {
-    auto txinfo = m_mempool.info(gtxid);
+    auto txinfo = m_mempool->info(gtxid);
     if (txinfo.tx) {
         // If a TX could have been INVed in reply to a MEMPOOL request,
         // or is older than UNCONDITIONAL_RELAY_DELAY, permit the request
@@ -1942,12 +1942,12 @@ void PeerManagerImpl::ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic
             // WTX and WITNESS_TX imply we serialize with witness
             int nSendFlags = (inv.IsMsgTx() ? SERIALIZE_TRANSACTION_NO_WITNESS : 0);
             m_connman.PushMessage(&pfrom, msgMaker.Make(nSendFlags, NetMsgType::TX, *tx));
-            m_mempool.RemoveUnbroadcastTx(tx->GetHash());
+            m_mempool->RemoveUnbroadcastTx(tx->GetHash());
             // As we're going to send tx, make sure its unconfirmed parents are made requestable.
             std::vector<uint256> parent_ids_to_add;
             {
-                LOCK(m_mempool.cs);
-                auto txiter = m_mempool.GetIter(tx->GetHash());
+                LOCK(m_mempool->cs);
+                auto txiter = m_mempool->GetIter(tx->GetHash());
                 if (txiter) {
                     const CTxMemPoolEntry::Parents& parents = (*txiter)->GetMemPoolParentsConst();
                     parent_ids_to_add.reserve(parents.size());
@@ -2231,7 +2231,7 @@ void PeerManagerImpl::ProcessOrphanTx(std::set<uint256>& orphan_work_set)
         const auto [porphanTx, from_peer] = m_orphanage.GetTx(orphanHash);
         if (porphanTx == nullptr) continue;
 
-        const MempoolAcceptResult result = AcceptToMemoryPool(m_chainman.ActiveChainstate(), m_mempool, porphanTx, false /* bypass_limits */);
+        const MempoolAcceptResult result = AcceptToMemoryPool(m_chainman.ActiveChainstate(), *m_mempool, porphanTx, false /* bypass_limits */);
         const TxValidationState& state = result.m_state;
 
         if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
@@ -2288,7 +2288,7 @@ void PeerManagerImpl::ProcessOrphanTx(std::set<uint256>& orphan_work_set)
             break;
         }
     }
-    m_mempool.check(m_chainman.ActiveChainstate());
+    m_mempool->check(m_chainman.ActiveChainstate());
 }
 
 bool PeerManagerImpl::PrepareBlockFilterRequest(CNode& peer,
@@ -3236,7 +3236,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                 // Always relay transactions received from peers with forcerelay
                 // permission, even if they were already in the mempool, allowing
                 // the node to function as a gateway for nodes hidden behind it.
-                if (!m_mempool.exists(tx.GetHash())) {
+                if (!m_mempool->exists(tx.GetHash())) {
                     LogPrintf("Not relaying non-mempool transaction %s from forcerelay peer=%d\n", tx.GetHash().ToString(), pfrom.GetId());
                 } else {
                     LogPrintf("Force relaying tx %s from peer=%d\n", tx.GetHash().ToString(), pfrom.GetId());
@@ -3246,11 +3246,11 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             return;
         }
 
-        const MempoolAcceptResult result = AcceptToMemoryPool(m_chainman.ActiveChainstate(), m_mempool, ptx, false /* bypass_limits */);
+        const MempoolAcceptResult result = AcceptToMemoryPool(m_chainman.ActiveChainstate(), *m_mempool, ptx, false /* bypass_limits */);
         const TxValidationState& state = result.m_state;
 
         if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
-            m_mempool.check(m_chainman.ActiveChainstate());
+            m_mempool->check(m_chainman.ActiveChainstate());
             // As this version of the transaction was acceptable, we can forget about any
             // requests for it.
             m_txrequest.ForgetTxHash(tx.GetHash());
@@ -3263,7 +3263,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             LogPrint(BCLog::MEMPOOL, "AcceptToMemoryPool: peer=%d: accepted %s (poolsz %u txn, %u kB)\n",
                 pfrom.GetId(),
                 tx.GetHash().ToString(),
-                m_mempool.size(), m_mempool.DynamicMemoryUsage() / 1000);
+                m_mempool->size(), m_mempool->DynamicMemoryUsage() / 1000);
 
             for (const CTransactionRef& removedTx : result.m_replaced_transactions.value()) {
                 AddToCompactExtraTransactions(removedTx);
@@ -3498,7 +3498,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                 std::list<QueuedBlock>::iterator* queuedBlockIt = nullptr;
                 if (!BlockRequested(pfrom.GetId(), *pindex, &queuedBlockIt)) {
                     if (!(*queuedBlockIt)->partialBlock)
-                        (*queuedBlockIt)->partialBlock.reset(new PartiallyDownloadedBlock(&m_mempool));
+                        (*queuedBlockIt)->partialBlock.reset(new PartiallyDownloadedBlock(m_mempool));
                     else {
                         // The block was already in flight using compact blocks from the same peer
                         LogPrint(BCLog::NET, "Peer sent us compact block we were already syncing!\n");
@@ -3541,7 +3541,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                 // download from.
                 // Optimistically try to reconstruct anyway since we might be
                 // able to without any round trips.
-                PartiallyDownloadedBlock tempBlock(&m_mempool);
+                PartiallyDownloadedBlock tempBlock(m_mempool);
                 ReadStatus status = tempBlock.InitData(cmpctblock, vExtraTxnForCompact);
                 if (status != READ_STATUS_OK) {
                     // TODO: don't ignore failures
@@ -4416,7 +4416,7 @@ void PeerManagerImpl::MaybeSendFeefilter(CNode& pto, std::chrono::microseconds c
     // peers with the forcerelay permission should not filter txs to us
     if (pto.HasPermission(NetPermissionFlags::ForceRelay)) return;
 
-    CAmount currentFilter = m_mempool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK();
+    CAmount currentFilter = m_mempool->GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK();
     static FeeFilterRounder g_filter_rounder{CFeeRate{DEFAULT_MIN_RELAY_TX_FEE}};
 
     if (m_chainman.ActiveChainstate().IsInitialBlockDownload()) {
@@ -4733,7 +4733,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
 
                 // Respond to BIP35 mempool requests
                 if (fSendTrickle && pto->m_tx_relay->fSendMempool) {
-                    auto vtxinfo = m_mempool.infoAll();
+                    auto vtxinfo = m_mempool->infoAll();
                     pto->m_tx_relay->fSendMempool = false;
                     const CFeeRate filterrate{pto->m_tx_relay->minFeeFilter.load()};
 
@@ -4772,7 +4772,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                     const CFeeRate filterrate{pto->m_tx_relay->minFeeFilter.load()};
                     // Topologically and fee-rate sort the inventory we send for privacy and priority reasons.
                     // A heap is used so that not all items need sorting if only a few are being sent.
-                    CompareInvMempoolOrder compareInvMempoolOrder(&m_mempool, state.m_wtxid_relay);
+                    CompareInvMempoolOrder compareInvMempoolOrder(m_mempool, state.m_wtxid_relay);
                     std::make_heap(vInvTx.begin(), vInvTx.end(), compareInvMempoolOrder);
                     // No reason to drain out at many times the network's capacity,
                     // especially since we have many peers and some will draw much shorter delays.
@@ -4792,7 +4792,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                             continue;
                         }
                         // Not in the mempool anymore? don't bother sending it.
-                        auto txinfo = m_mempool.info(ToGenTxid(inv));
+                        auto txinfo = m_mempool->info(ToGenTxid(inv));
                         if (!txinfo.tx) {
                             continue;
                         }

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -39,7 +39,7 @@ class PeerManager : public CValidationInterface, public NetEventsInterface
 public:
     static std::unique_ptr<PeerManager> make(const CChainParams& chainparams, CConnman& connman, CAddrMan& addrman,
                                              BanMan* banman, ChainstateManager& chainman,
-                                             CTxMemPool& pool, bool ignore_incoming_txs);
+                                             CTxMemPool* pool, bool ignore_incoming_txs);
     virtual ~PeerManager() { }
 
     /** Begin running background tasks, should only be called once */

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -28,7 +28,7 @@ static const unsigned int MIN_STANDARD_TX_NONWITNESS_SIZE = 82;
 static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */
 static const unsigned int MAX_STANDARD_TX_SIGOPS_COST = MAX_BLOCK_SIGOPS_COST/5;
-/** Default for -maxmempool, maximum megabytes of mempool memory usage */
+/** Default for -maxmempool, maximum megabytes of mempool memory usage if the mempool exists*/
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /** Default for -incrementalrelayfee, which sets the minimum feerate increase for mempool limiting or BIP 125 replacement **/
 static const unsigned int DEFAULT_INCREMENTAL_RELAY_FEE = 1000;

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     const CChainParams& chainparams = Params();
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, nullptr,
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, m_node.mempool.get(), false);
 
     // Mock an outbound peer
     CAddress addr1(ip(0xa0b0c001), NODE_NONE);
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
     const CChainParams& chainparams = Params();
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, nullptr,
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, m_node.mempool.get(), false);
 
     constexpr int max_outbound_full_relay = MAX_OUTBOUND_FULL_RELAY_CONNECTIONS;
     CConnman::Options options;
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     auto banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(),
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, m_node.mempool.get(), false);
 
     CNetAddr tor_netaddr;
     BOOST_REQUIRE(
@@ -288,7 +288,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     auto banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(),
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, m_node.mempool.get(), false);
 
     banman->ClearBanned();
     int64_t nStartTime = GetTime();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -198,7 +198,7 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
     m_node.connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman); // Deterministic randomness for tests.
     m_node.peerman = PeerManager::make(chainparams, *m_node.connman, *m_node.addrman,
                                        m_node.banman.get(), *m_node.chainman,
-                                       *m_node.mempool, false);
+                                       m_node.mempool.get(), false);
     {
         CConnman::Options options;
         options.m_msgproc = m_node.peerman.get();

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -36,6 +36,8 @@ extern RecursiveMutex cs_main;
 
 /** Fake height value used in Coin to signify they are only in the memory pool (since 0.8) */
 static const uint32_t MEMPOOL_HEIGHT = 0x7FFFFFFF;
+/** Default for mempool initialization*/
+static const bool DEFAULT_INITMEMPOOL = true;
 
 struct LockPoints
 {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1995,7 +1995,7 @@ CoinsCacheSizeState CChainState::GetCoinsCacheSizeState()
 {
     return this->GetCoinsCacheSizeState(
         m_coinstip_cache_size_bytes,
-        gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000);
+        gArgs.GetBoolArg("-mempool", DEFAULT_INITMEMPOOL) ? gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000 : 0);
 }
 
 CoinsCacheSizeState CChainState::GetCoinsCacheSizeState(

--- a/src/validation.h
+++ b/src/validation.h
@@ -580,7 +580,7 @@ protected:
     mutable std::atomic<bool> m_cached_finished_ibd{false};
 
     //! Optional mempool that is kept in sync with the chain.
-    //! Only the active chainstate has a mempool.
+    //! At most, only the active chainstate has a mempool.
     CTxMemPool* m_mempool;
 
     const CChainParams& m_params;

--- a/test/functional/no_mempool.py
+++ b/test/functional/no_mempool.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test a node with the -nomempool option.
+
+- Test that getnetworkhashps RPC works when -nomempool is set
+- Test that generatetoaddress RPC does not work when -nomempool is set
+- Test that getblocktemplate RPC does not work when -nomempool is set
+"""
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_raises_rpc_error,
+)
+from test_framework.blocktools import (
+    NORMAL_GBT_REQUEST_PARAMS,
+)
+
+class NoMempoolTest (BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [["-nomempool"]]
+
+    def run_test (self):
+        node = self.nodes[0]
+
+        # `getnetworkhashps` does not ensure that a mempool exists, this should not throw an error
+        node.getnetworkhashps()
+
+        # The `generatetoaddress` RPC function called by node.generate ensures
+        # that a mempool exists, by calling `EnsureMemPool`
+        assert_raises_rpc_error(-33, "Mempool disabled or instance not found", node.generate, 101)
+
+        # The `getblocktemplate` RPC function ensures that a mempool exists, by calling `EnsureMemPool`
+        assert_raises_rpc_error(-33, "Mempool disabled or instance not found", node.getblocktemplate, NORMAL_GBT_REQUEST_PARAMS)
+
+if __name__ == '__main__':
+    NoMempoolTest().main ()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -682,7 +682,12 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
 
     def sync_all(self, nodes=None):
         self.sync_blocks(nodes)
-        self.sync_mempools(nodes)
+        try:
+            self.sync_mempools(nodes)
+        except JSONRPCException as e:
+            if (e.error["code"]) != -33 or ("Mempool disabled or instance not found" not in e.error['message']):
+                raise e
+            self.log.info("Mempool disabled or instance not found, unable to sync mempools of the nodes")
 
     def wait_until(self, test_function, timeout=60):
         return wait_until_helper(test_function, timeout=timeout, timeout_factor=self.options.timeout_factor)

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -235,7 +235,12 @@ class TestNode():
                 if self.version_is_at_least(190000):
                     # getmempoolinfo.loaded is available since commit
                     # bb8ae2c (version 0.19.0)
-                    wait_until_helper(lambda: rpc.getmempoolinfo()['loaded'], timeout_factor=self.timeout_factor)
+                    try:
+                        wait_until_helper(lambda: rpc.getmempoolinfo()['loaded'], timeout_factor=self.timeout_factor)
+                    except JSONRPCException as e:
+                        if (e.error["code"]) != -33 or ("Mempool disabled or instance not found" not in e.error['message']):
+                            raise e
+                        self.log.info("Mempool disabled or instance not found")
                     # Wait for the node to finish reindex, block import, and
                     # loading the mempool. Usually importing happens fast or
                     # even "immediate" when the node is started. However, there


### PR DESCRIPTION
This PR adds a -mempool runtime setting that will allow a node to control the initialization of the mempool. A user who is only interested in confirmed transactions might want to disable the mempool by running Bitcoin Core with `-mempool=0` or `-nomempool`.

At this point, Bitcoin Core will throw an error when someone calls an RPC function that requires the mempool. The PR also adds a functional test which checks a few RPC calls that (do not) have a mempool dependency.