### PR TITLE
net: Make m_mempool optional in PeerManager

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1208,7 +1208,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     assert(!node.peerman);
     node.peerman = PeerManager::make(chainparams, *node.connman, *node.addrman, node.banman.get(),
-                                     chainman, *node.mempool, ignores_incoming_txs);
+                                     chainman, node.mempool.get(), ignores_incoming_txs);
     RegisterValidationInterface(node.peerman.get());
 
     // sanitize comments per BIP-0014, format user agent and check total size

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -39,7 +39,7 @@ class PeerManager : public CValidationInterface, public NetEventsInterface
 public:
     static std::unique_ptr<PeerManager> make(const CChainParams& chainparams, CConnman& connman, CAddrMan& addrman,
                                              BanMan* banman, ChainstateManager& chainman,
-                                             CTxMemPool& pool, bool ignore_incoming_txs);
+                                             CTxMemPool* pool, bool ignore_incoming_txs);
     virtual ~PeerManager() { }
 
     /** Begin running background tasks, should only be called once */

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     const CChainParams& chainparams = Params();
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, nullptr,
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, m_node.mempool.get(), false);
 
     // Mock an outbound peer
     CAddress addr1(ip(0xa0b0c001), NODE_NONE);
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
     const CChainParams& chainparams = Params();
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, nullptr,
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, m_node.mempool.get(), false);
 
     constexpr int max_outbound_full_relay = MAX_OUTBOUND_FULL_RELAY_CONNECTIONS;
     CConnman::Options options;
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     auto banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(),
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, m_node.mempool.get(), false);
 
     CNetAddr tor_netaddr;
     BOOST_REQUIRE(
@@ -288,7 +288,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     auto banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(),
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, m_node.mempool.get(), false);
 
     banman->ClearBanned();
     int64_t nStartTime = GetTime();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -198,7 +198,7 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
     m_node.connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman); // Deterministic randomness for tests.
     m_node.peerman = PeerManager::make(chainparams, *m_node.connman, *m_node.addrman,
                                        m_node.banman.get(), *m_node.chainman,
-                                       *m_node.mempool, false);
+                                       m_node.mempool.get(), false);
     {
         CConnman::Options options;
         options.m_msgproc = m_node.peerman.get();


### PR DESCRIPTION
Make `m_mempool` an optional pointer in PeerManager, instead of a reference. This is a prerequisite for the introduction of a `-nomempool` option.

To test that the null-pointer-dereference checks in PeerManagerImpl work, build the [test-peerman-mempool-ptr](https://github.com/sriramdvt/bitcoin/tree/test-peerman-mempool-ptr) branch that [does not have a mempool initialized](https://github.com/sriramdvt/bitcoin/compare/peerman-mempool-ptr...sriramdvt:test-peerman-mempool-ptr), and run it on signet/testnet (the functional tests would not work on [test-peerman-mempool-ptr](https://github.com/sriramdvt/bitcoin/tree/test-peerman-mempool-ptr) since the mempool is absent).